### PR TITLE
Fixed Crs deserialisation on FeatureCollection. Added test

### DIFF
--- a/src/GeoJSON.Net.Tests/DeserializationTest.cs
+++ b/src/GeoJSON.Net.Tests/DeserializationTest.cs
@@ -1,4 +1,5 @@
-﻿using GeoJSON.Net.Geometry;
+﻿using GeoJSON.Net.Feature;
+using GeoJSON.Net.Geometry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -118,5 +119,18 @@ namespace GeoJSON.Net.Tests
             Assert.IsTrue(coordinates.Latitude + 52.379790828551016 < 0.0001);
         }
 
+        [TestMethod]
+        public void FeatureCollectionDeserialization()
+        {
+            var geoJsonText = @"{'type': 'FeatureCollection', 'crs': {'type': 'name','properties': {'name': 'urn:ogc:def:crs:OGC:1.3:CRS84'}},
+                'features': [{'type': 'Feature','properties': {'ITEM_CODE': 'PB','UNIQUE_ID': '1570',},'geometry': {'type': 'Polygon', 'coordinates': [[
+                [-0.12513, 51.542634],[-0.125125,51.542618],[-0.125279,51.542595],[-0.125362,51.542583],[-0.125369,51.542601],[-0.12513,51.542634]]]}}]}";
+
+            var featureCollection = JsonConvert.DeserializeObject<FeatureCollection>(geoJsonText,
+                new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+
+            Assert.IsNotNull(featureCollection);
+            Assert.AreEqual(1, featureCollection.Features.Count);
+        }
     }
 }

--- a/src/GeoJSON.Net.Tests/DeserializationTest.cs
+++ b/src/GeoJSON.Net.Tests/DeserializationTest.cs
@@ -4,9 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace GeoJSON.Net.Tests
 {
@@ -122,7 +119,7 @@ namespace GeoJSON.Net.Tests
         [TestMethod]
         public void FeatureCollectionDeserialization()
         {
-            var geoJsonText = @"{'type': 'FeatureCollection', 'crs': {'type': 'name','properties': {'name': 'urn:ogc:def:crs:OGC:1.3:CRS84'}},
+            const string geoJsonText = @"{'type': 'FeatureCollection', 'crs': {'type': 'name','properties': {'name': 'urn:ogc:def:crs:OGC:1.3:CRS84'}},
                 'features': [{'type': 'Feature','properties': {'ITEM_CODE': 'PB','UNIQUE_ID': '1570',},'geometry': {'type': 'Polygon', 'coordinates': [[
                 [-0.12513, 51.542634],[-0.125125,51.542618],[-0.125279,51.542595],[-0.125362,51.542583],[-0.125369,51.542601],[-0.12513,51.542634]]]}}]}";
 

--- a/src/GeoJSON.Net.Tests/MiscTest.cs
+++ b/src/GeoJSON.Net.Tests/MiscTest.cs
@@ -1,15 +1,7 @@
-﻿using GeoJSON.Net.Converters;
-using GeoJSON.Net.Feature;
-using GeoJSON.Net.Geometry;
+﻿using GeoJSON.Net.Geometry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading;
 
 namespace GeoJSON.Net.Tests
 {

--- a/src/GeoJSON.Net.Tests/SerializationTest.cs
+++ b/src/GeoJSON.Net.Tests/SerializationTest.cs
@@ -1,6 +1,5 @@
-﻿using GeoJSON.Net.Converters;
+﻿using GeoJSON.Net.Feature;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using GeoJSON.Net.Feature;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -8,8 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Text.RegularExpressions;
 
 namespace GeoJSON.Net.Tests
@@ -23,9 +20,9 @@ namespace GeoJSON.Net.Tests
         [TestMethod]
         public void PointFeatureSerialization() 
         {
-            var point = new GeoJSON.Net.Geometry.Point(new GeoJSON.Net.Geometry.GeographicPosition(45.79012, 15.94107));
+            var point = new Point(new GeographicPosition(45.79012, 15.94107));
             var featureProperties = new Dictionary<string, object> { {"Name", "Foo"} };
-            var model = new GeoJSON.Net.Feature.Feature(point, featureProperties);
+            var model = new Feature.Feature(point, featureProperties);
             var serializedData = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver(), NullValueHandling = NullValueHandling.Ignore });
 
             Assert.IsFalse(serializedData.Contains("longitude"));
@@ -44,7 +41,7 @@ namespace GeoJSON.Net.Tests
 
             var polygon = new Polygon(new List<LineString> { new LineString(coordinates) });
             var featureProperties = new Dictionary<string, object> { { "Name", "Foo" } };
-            var model = new GeoJSON.Net.Feature.Feature(polygon, featureProperties);
+            var model = new Feature.Feature(polygon, featureProperties);
 
             var serializedData = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver(), NullValueHandling = NullValueHandling.Ignore });
         }
@@ -78,7 +75,7 @@ namespace GeoJSON.Net.Tests
         [TestMethod]
         public void GeographicPositionSerialization()
         {
-            var model = new GeoJSON.Net.Geometry.GeographicPosition(112.12, 10);
+            var model = new GeographicPosition(112.12, 10);
 
             var serialized = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 
@@ -90,7 +87,30 @@ namespace GeoJSON.Net.Tests
             Assert.AreEqual(lng, 112.12);
         }
 
+        [TestMethod]
+        public void FeatureCollectionSerialization()
+        {
+            var model = new FeatureCollection(null);
+            for (var i = 10; i-->0;)
+            {
+                var geom = new LineString(new[]
+                {
+                    new GeographicPosition(51.010, -1.034),
+                    new GeographicPosition(51.010, -0.034),
+                });
 
-       
+                var props = new Dictionary<string, object>();
+                props.Add("test1", "1");
+                props.Add("test2", 2);
+
+                var feature = new Feature.Feature(geom, props);
+                model.Features.Add(feature);
+            }
+
+            var serialized = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+            
+            Assert.IsNotNull(serialized);
+            Assert.IsFalse(string.IsNullOrEmpty(serialized));
+        }
     }
 }

--- a/src/GeoJSON.Net/Converters/CrsConverter.cs
+++ b/src/GeoJSON.Net/Converters/CrsConverter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using GeoJSON.Net.CoordinateReferenceSystem;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GeoJSON.Net.Converters
+{
+    class CrsConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            var typeName = jsonObject["type"].ToString().ToLower();
+
+            switch (typeName)
+            {
+                case "name":
+                    JObject propName = null;
+                    JToken jt;
+                    if (jsonObject.TryGetValue("properties", out jt))
+                    {
+                        propName = JObject.Parse(jt.ToString());
+                    }
+
+                    if (propName != null)
+                    {
+                        var target = new NamedCRS(propName["name"].ToString());
+                        serializer.Populate(jsonObject.CreateReader(), target);
+                        return target;
+                    }
+                    break;
+                case "link":
+                    var linked = new LinkedCRS("");
+                    serializer.Populate(jsonObject.CreateReader(), linked);
+                    return linked;
+            }
+
+            return new NotSupportedException(string.Format("Type {0} unexpected.", typeName));
+        }
+
+
+        public override bool CanConvert(Type objectType)
+        {
+            if (objectType.IsInterface)
+            {
+                return objectType == typeof(ICRSObject);
+            }
+
+            return typeof(ICRSObject).IsAssignableFrom(objectType);
+        }
+
+
+    }
+}

--- a/src/GeoJSON.Net/Converters/GeometryConverter.cs
+++ b/src/GeoJSON.Net/Converters/GeometryConverter.cs
@@ -31,7 +31,8 @@ namespace GeoJSON.Net.Converters
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             if (value is GeoJSON.Net.Geometry.Point
-                || value is GeoJSON.Net.Geometry.Polygon) 
+                || value is GeoJSON.Net.Geometry.Polygon
+                || value is GeoJSON.Net.Geometry.LineString)
             {
                 serializer.Serialize(writer, value);
             }
@@ -61,10 +62,10 @@ namespace GeoJSON.Net.Converters
             { 
                 case "polygon":
                     return JsonConvert.DeserializeObject<Polygon>(inputJsonValue, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
-                    break;
                 case "point":
                     return JsonConvert.DeserializeObject<Point>(inputJsonValue, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
-                    break;
+                case "linestring":
+                    return JsonConvert.DeserializeObject<LineString>(inputJsonValue, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
             }
 
             // ToDo: implement

--- a/src/GeoJSON.Net/CoordinateReferenceSystem/LinkedCRS.cs
+++ b/src/GeoJSON.Net/CoordinateReferenceSystem/LinkedCRS.cs
@@ -15,7 +15,7 @@ namespace GeoJSON.Net.CoordinateReferenceSystem
     /// <summary>
     /// Defines the <see cref="http://geojson.org/geojson-spec.html#linked-crs">Linked CRS type</see>.
     /// </summary>
-    public class LinkedCRS : CRSBase
+    public class LinkedCRS : CRSBase, ICRSObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LinkedCRS"/> class.

--- a/src/GeoJSON.Net/CoordinateReferenceSystem/NamedCRS.cs
+++ b/src/GeoJSON.Net/CoordinateReferenceSystem/NamedCRS.cs
@@ -15,7 +15,7 @@ namespace GeoJSON.Net.CoordinateReferenceSystem
     /// <summary>
     /// Defines the <see cref="http://geojson.org/geojson-spec.html#named-crs">Named CRS type</see>.
     /// </summary>
-    public class NamedCRS : CRSBase
+    public class NamedCRS : CRSBase, ICRSObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NamedCRS"/> class.

--- a/src/GeoJSON.Net/Feature/FeatureCollection.cs
+++ b/src/GeoJSON.Net/Feature/FeatureCollection.cs
@@ -24,7 +24,7 @@ namespace GeoJSON.Net.Feature
         /// <param name="features">The features.</param>
         public FeatureCollection(List<Feature> features)
         {
-            this.Features = features;
+            this.Features = features ?? new List<Feature>();
 
             this.Type = GeoJSONObjectType.FeatureCollection;
         }

--- a/src/GeoJSON.Net/GeoJSON.Net.csproj
+++ b/src/GeoJSON.Net/GeoJSON.Net.csproj
@@ -42,6 +42,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Converters\CrsConverter.cs" />
     <Compile Include="Converters\GeometryConverter.cs" />
     <Compile Include="Converters\PointConverter.cs" />
     <Compile Include="Converters\PolygonConverter.cs" />

--- a/src/GeoJSON.Net/GeoJSONObject.cs
+++ b/src/GeoJSON.Net/GeoJSONObject.cs
@@ -7,6 +7,7 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using GeoJSON.Net.Converters;
 using Newtonsoft.Json.Converters;
 
 namespace GeoJSON.Net
@@ -36,6 +37,7 @@ namespace GeoJSON.Net
         /// The Coordinate Reference System Objects.
         /// </value>
         [JsonProperty(PropertyName = "crs", Required = Required.Default)]
+        [JsonConverter(typeof(CrsConverter))]
         public CoordinateReferenceSystem.ICRSObject CRS { get; set; }
 
         /// <summary>

--- a/src/GeoJSON.Net/Geometry/LineString.cs
+++ b/src/GeoJSON.Net/Geometry/LineString.cs
@@ -7,12 +7,14 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.Linq;
+
 namespace GeoJSON.Net.Geometry
 {
     using System;
     using System.Collections.Generic;
 
-    using GeoJSON.Net.Converters;
+    using Converters;
 
     using Newtonsoft.Json;
 
@@ -26,20 +28,22 @@ namespace GeoJSON.Net.Geometry
         /// Initializes a new instance of the <see cref="LineString"/> class.
         /// </summary>
         /// <param name="coordinates">The coordinates.</param>
-        public LineString(List<IPosition> coordinates)
+        public LineString(IEnumerable<IPosition> coordinates)
         {
             if (coordinates == null)
             {
                 throw new ArgumentNullException("coordinates");
             }
 
-            if (coordinates.Count < 2)
+            var coordsList = coordinates.ToList();
+
+            if (coordsList.Count < 2)
             {
                 throw new ArgumentOutOfRangeException("coordinates", "According to the GeoJSON v1.0 spec a LineString must have at least two or more positions.");
             }
 
-            this.Coordinates = coordinates;
-            this.Type = GeoJSONObjectType.LineString;
+            Coordinates = coordsList;
+            Type = GeoJSONObjectType.LineString;
         }
 
         /// <summary>
@@ -58,7 +62,7 @@ namespace GeoJSON.Net.Geometry
         /// </returns>
         public bool IsLinearRing()
         {
-            return this.Coordinates.Count >= 4 && this.IsClosed();
+            return Coordinates.Count >= 4 && IsClosed();
         }
 
         /// <summary>
@@ -69,17 +73,17 @@ namespace GeoJSON.Net.Geometry
         /// </returns>
         public bool IsClosed()
         {
-            if (this.Coordinates[0] is GeographicPosition) 
+            if (Coordinates[0] is GeographicPosition) 
             {
-                var firstCoordinate = this.Coordinates[0] as GeographicPosition;
-                var lastCoordinate = this.Coordinates[this.Coordinates.Count - 1] as GeographicPosition;
+                var firstCoordinate = Coordinates[0] as GeographicPosition;
+                var lastCoordinate = Coordinates[Coordinates.Count - 1] as GeographicPosition;
 
                 return firstCoordinate.Latitude == lastCoordinate.Latitude
                     && firstCoordinate.Longitude == lastCoordinate.Longitude
                     && firstCoordinate.Altitude == lastCoordinate.Altitude;
             }
             else
-                return this.Coordinates[0].Equals(this.Coordinates[this.Coordinates.Count - 1]);
+                return Coordinates[0].Equals(Coordinates[Coordinates.Count - 1]);
         }
     }
 }


### PR DESCRIPTION
When trying to deserialize a FeatureCollection the crs property would always fail due to NamedCRS and LinkedCRS not implementing ICRSObject and needed a converter, CrsConverter
Have fixed this and added a test