### PR TITLE
Add serialization and deserialization for CRS

### DIFF
--- a/src/GeoJSON.Net.Tests/DeserializationTest.cs
+++ b/src/GeoJSON.Net.Tests/DeserializationTest.cs
@@ -1,11 +1,10 @@
-﻿using GeoJSON.Net.Geometry;
+﻿using GeoJSON.Net.Feature;
+using GeoJSON.Net.Geometry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace GeoJSON.Net.Tests
 {
@@ -382,7 +381,21 @@ namespace GeoJSON.Net.Tests
             Assert.IsNotNull(thirdPoint);
             Assert.IsTrue(thirdPoint.Altitude.HasValue);
             Assert.AreEqual(4.23, thirdPoint.Altitude.Value, 0.0001);
+        }
 
+        [TestMethod]
+        public void FeatureCollectionDeserialization()
+        {
+            const string geoJsonText = @"{'type': 'FeatureCollection', 'crs': {'type': 'name','properties': {'name': 'urn:ogc:def:crs:OGC:1.3:CRS84'}},
+                'features': [{'type': 'Feature','properties': {'ITEM_CODE': 'PB','UNIQUE_ID': '1570',},'geometry': {'type': 'Polygon', 'coordinates': [[
+                [-0.12513, 51.542634],[-0.125125,51.542618],[-0.125279,51.542595],[-0.125362,51.542583],[-0.125369,51.542601],[-0.12513,51.542634]]]}}]}";
+
+            var featureCollection = JsonConvert.DeserializeObject<FeatureCollection>(geoJsonText,
+                new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+
+            Assert.IsNotNull(featureCollection);
+            Assert.AreEqual(1, featureCollection.Features.Count);
         }
     }
 }
+

--- a/src/GeoJSON.Net.Tests/MiscTest.cs
+++ b/src/GeoJSON.Net.Tests/MiscTest.cs
@@ -1,15 +1,8 @@
-﻿using GeoJSON.Net.Converters;
-using GeoJSON.Net.Feature;
-using GeoJSON.Net.Geometry;
+﻿using GeoJSON.Net.Geometry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading;
 
 namespace GeoJSON.Net.Tests
 {
@@ -20,7 +13,7 @@ namespace GeoJSON.Net.Tests
         /// Test that the last coordinate must be the same as the first to complete the polygon
         /// </summary>
         [TestMethod]
-        public void LineStringIsClosed() 
+        public void LineStringIsClosed()
         {
             var coordinates = new List<GeographicPosition> 
             { 
@@ -35,7 +28,7 @@ namespace GeoJSON.Net.Tests
 
 
         [TestMethod]
-        public void ComparePolygons() 
+        public void ComparePolygons()
         {
             var coordinates = new List<GeographicPosition> 
                 { 
@@ -74,43 +67,43 @@ namespace GeoJSON.Net.Tests
 
         }
 
-				[TestMethod]
-				public void TestFeatureFromClass()
-				{
-					var testObject = new MyTestClass()
-						{
-							BooleanProperty = true,
-							DateTimeProperty = DateTime.Now,
-							DoubleProperty = 1.2345d,
-							EnumProperty = MyTestEnum.Value1,
-							IntProperty = -1,
-							StringProperty = "Hello, GeoJSON !"
-						};
+        [TestMethod]
+        public void TestFeatureFromClass()
+        {
+            var testObject = new MyTestClass()
+                {
+                    BooleanProperty = true,
+                    DateTimeProperty = DateTime.Now,
+                    DoubleProperty = 1.2345d,
+                    EnumProperty = MyTestEnum.Value1,
+                    IntProperty = -1,
+                    StringProperty = "Hello, GeoJSON !"
+                };
 
-					Feature.Feature feature = new Feature.Feature(new Point(new GeographicPosition(10, 10)), testObject);
+            Feature.Feature feature = new Feature.Feature(new Point(new GeographicPosition(10, 10)), testObject);
 
-					Assert.IsNotNull(feature.Properties);
-					Assert.IsTrue(feature.Properties.Count > 1);
-					Assert.AreEqual(feature.Properties.Count, 6);
+            Assert.IsNotNull(feature.Properties);
+            Assert.IsTrue(feature.Properties.Count > 1);
+            Assert.AreEqual(feature.Properties.Count, 6);
 
-				}
+        }
 
-				public enum MyTestEnum
-				{
-					Undefined,
-					Value1,
-					Value2
-				}
-				public class MyTestClass
-				{
-					public int IntProperty { get; set; }
-					public string StringProperty { get; set; }
-					public DateTime DateTimeProperty { get; set; }
-					public double DoubleProperty { get; set; }
-					public bool BooleanProperty { get; set; }
-					public MyTestEnum EnumProperty { get; set; }
-				}
+        public enum MyTestEnum
+        {
+            Undefined,
+            Value1,
+            Value2
+        }
+        public class MyTestClass
+        {
+            public int IntProperty { get; set; }
+            public string StringProperty { get; set; }
+            public DateTime DateTimeProperty { get; set; }
+            public double DoubleProperty { get; set; }
+            public bool BooleanProperty { get; set; }
+            public MyTestEnum EnumProperty { get; set; }
+        }
 
-			
+
     }
 }

--- a/src/GeoJSON.Net.Tests/SerializationTest.cs
+++ b/src/GeoJSON.Net.Tests/SerializationTest.cs
@@ -1,6 +1,5 @@
-﻿using GeoJSON.Net.Converters;
+﻿using GeoJSON.Net.Feature;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using GeoJSON.Net.Feature;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -9,8 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Text.RegularExpressions;
 
 namespace GeoJSON.Net.Tests
@@ -24,9 +21,9 @@ namespace GeoJSON.Net.Tests
         [TestMethod]
         public void PointFeatureSerialization() 
         {
-            var point = new GeoJSON.Net.Geometry.Point(new GeoJSON.Net.Geometry.GeographicPosition(45.79012, 15.94107));
+            var point = new Point(new GeographicPosition(45.79012, 15.94107));
             var featureProperties = new Dictionary<string, object> { {"Name", "Foo"} };
-            var model = new GeoJSON.Net.Feature.Feature(point, featureProperties);
+            var model = new Feature.Feature(point, featureProperties);
             var serializedData = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver(), NullValueHandling = NullValueHandling.Ignore });
 
             Assert.IsFalse(serializedData.Contains("longitude"));
@@ -45,7 +42,7 @@ namespace GeoJSON.Net.Tests
 
             var polygon = new Polygon(new List<LineString> { new LineString(coordinates) });
             var featureProperties = new Dictionary<string, object> { { "Name", "Foo" } };
-            var model = new GeoJSON.Net.Feature.Feature(polygon, featureProperties);
+            var model = new Feature.Feature(polygon, featureProperties);
 
             var serializedData = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver(), NullValueHandling = NullValueHandling.Ignore });
         }
@@ -114,7 +111,7 @@ namespace GeoJSON.Net.Tests
         [TestMethod]
         public void GeographicPositionSerialization()
         {
-            var model = new GeoJSON.Net.Geometry.GeographicPosition(112.12, 10);
+            var model = new GeographicPosition(112.12, 10);
 
             var serialized = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 
@@ -124,6 +121,32 @@ namespace GeoJSON.Net.Tests
             double.TryParse(matches[0].Value, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out lng);
 
             Assert.AreEqual(lng, 112.12);
+        }
+
+        [TestMethod]
+        public void FeatureCollectionSerialization()
+        {
+            var model = new FeatureCollection(null);
+            for (var i = 10; i-- > 0; )
+            {
+                var geom = new LineString(new[]
+                {
+                    new GeographicPosition(51.010, -1.034),
+                    new GeographicPosition(51.010, -0.034),
+                });
+
+                var props = new Dictionary<string, object>();
+                props.Add("test1", "1");
+                props.Add("test2", 2);
+
+                var feature = new Feature.Feature(geom, props);
+                model.Features.Add(feature);
+            }
+
+            var serialized = JsonConvert.SerializeObject(model, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+
+            Assert.IsNotNull(serialized);
+            Assert.IsFalse(string.IsNullOrEmpty(serialized));
         }
 
         [TestMethod]
@@ -158,7 +181,7 @@ namespace GeoJSON.Net.Tests
             geometry = new Polygon(coordinates.Select(ca => new LineString(ca)).ToList());
             AssertCoordinates(JsonConvert.SerializeObject(new Feature.Feature(geometry), settings), 2, coordinates);
         }
-
+       
         [TestMethod]
         public void MultiPolygonSerialization()
         {

--- a/src/GeoJSON.Net.Tests/SerializationTest.cs
+++ b/src/GeoJSON.Net.Tests/SerializationTest.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
+using GeoJSON.Net.CoordinateReferenceSystem;
 
 namespace GeoJSON.Net.Tests
 {
@@ -225,6 +226,50 @@ namespace GeoJSON.Net.Tests
             var serializedData = JsonConvert.SerializeObject(newFeature, Formatting.Indented, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver(), NullValueHandling = NullValueHandling.Ignore });
             var serializedDataWithouWhiteSpace = Regex.Replace(serializedData, @"(\s|$)+", "");
             Assert.IsTrue(serializedDataWithouWhiteSpace == expectedJson);
+        }
+
+        [TestMethod]
+        public void NamedCrsHasCorrectType()
+        {
+            var collection = new FeatureCollection(null);
+            collection.CRS = new NamedCRS("EPSG:31370");
+
+            Assert.AreEqual(CRSType.Name, collection.CRS.Type);
+        }
+
+        [TestMethod]
+        public void NamedCrsSerializationWithValue()
+        {
+            var collection = new FeatureCollection(null);
+            collection.CRS = new NamedCRS("EPSG:31370");
+
+            var serializedData = JsonConvert.SerializeObject(collection, Formatting.None, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver(), NullValueHandling = NullValueHandling.Ignore });
+            Assert.IsTrue(serializedData.Contains("\"crs\":{\"type\":\"Name\",\"properties\":{\"name\":\"EPSG:31370\"}}"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void NamedCrsSerializationNull()
+        {
+            var collection = new FeatureCollection(null);
+            collection.CRS = new NamedCRS(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void NamedCrsSerializationEmpty()
+        {
+            var collection = new FeatureCollection(null);
+            collection.CRS = new NamedCRS("");
+        }
+
+        [TestMethod]
+        public void NamedCrsSerializationNotSet()
+        {
+            var collection = new FeatureCollection(null);
+
+            var serializedData = JsonConvert.SerializeObject(collection, Formatting.None, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver(), NullValueHandling = NullValueHandling.Ignore });
+            Assert.IsTrue(!serializedData.Contains("\"crs\""));
         }
 
         private void AssertCoordinates(string geojson, int expectedNesting, IEnumerable<object> coords)

--- a/src/GeoJSON.Net/Converters/CrsConverter.cs
+++ b/src/GeoJSON.Net/Converters/CrsConverter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using GeoJSON.Net.CoordinateReferenceSystem;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GeoJSON.Net.Converters
+{
+    class CrsConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            var typeName = jsonObject["type"].ToString().ToLower();
+
+            switch (typeName)
+            {
+                case "name":
+                    JObject propName = null;
+                    JToken jt;
+                    if (jsonObject.TryGetValue("properties", out jt))
+                    {
+                        propName = JObject.Parse(jt.ToString());
+                    }
+
+                    if (propName != null)
+                    {
+                        var target = new NamedCRS(propName["name"].ToString());
+                        serializer.Populate(jsonObject.CreateReader(), target);
+                        return target;
+                    }
+                    break;
+                case "link":
+                    var linked = new LinkedCRS("");
+                    serializer.Populate(jsonObject.CreateReader(), linked);
+                    return linked;
+            }
+
+            return new NotSupportedException(string.Format("Type {0} unexpected.", typeName));
+        }
+
+
+        public override bool CanConvert(Type objectType)
+        {
+            if (objectType.IsInterface)
+            {
+                return objectType == typeof(ICRSObject);
+            }
+
+            return typeof(ICRSObject).IsAssignableFrom(objectType);
+        }
+
+
+    }
+}

--- a/src/GeoJSON.Net/Converters/GeometryConverter.cs
+++ b/src/GeoJSON.Net/Converters/GeometryConverter.cs
@@ -70,7 +70,9 @@ namespace GeoJSON.Net.Converters
                     return JsonConvert.DeserializeObject<Point>(inputJsonValue, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 				case "multipolygon":
 					return JsonConvert.DeserializeObject<MultiPolygon>(inputJsonValue, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
-			}
+                case "linestring":
+                    return JsonConvert.DeserializeObject<LineString>(inputJsonValue, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+            }
 
             // ToDo: implement
             throw new NotImplementedException();

--- a/src/GeoJSON.Net/CoordinateReferenceSystem/LinkedCRS.cs
+++ b/src/GeoJSON.Net/CoordinateReferenceSystem/LinkedCRS.cs
@@ -15,7 +15,7 @@ namespace GeoJSON.Net.CoordinateReferenceSystem
     /// <summary>
     /// Defines the <see cref="http://geojson.org/geojson-spec.html#linked-crs">Linked CRS type</see>.
     /// </summary>
-    public class LinkedCRS : CRSBase
+    public class LinkedCRS : CRSBase, ICRSObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LinkedCRS"/> class.

--- a/src/GeoJSON.Net/CoordinateReferenceSystem/NamedCRS.cs
+++ b/src/GeoJSON.Net/CoordinateReferenceSystem/NamedCRS.cs
@@ -15,7 +15,7 @@ namespace GeoJSON.Net.CoordinateReferenceSystem
     /// <summary>
     /// Defines the <see cref="http://geojson.org/geojson-spec.html#named-crs">Named CRS type</see>.
     /// </summary>
-    public class NamedCRS : CRSBase
+    public class NamedCRS : CRSBase, ICRSObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NamedCRS"/> class.

--- a/src/GeoJSON.Net/Feature/FeatureCollection.cs
+++ b/src/GeoJSON.Net/Feature/FeatureCollection.cs
@@ -24,7 +24,7 @@ namespace GeoJSON.Net.Feature
         /// <param name="features">The features.</param>
         public FeatureCollection(List<Feature> features)
         {
-            this.Features = features;
+            this.Features = features ?? new List<Feature>();
 
             this.Type = GeoJSONObjectType.FeatureCollection;
         }

--- a/src/GeoJSON.Net/GeoJSON.Net.csproj
+++ b/src/GeoJSON.Net/GeoJSON.Net.csproj
@@ -42,6 +42,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Converters\CrsConverter.cs" />
     <Compile Include="Converters\GeometryConverter.cs" />
     <Compile Include="Converters\MultiPolygonConverter.cs" />
     <Compile Include="Converters\PointConverter.cs" />

--- a/src/GeoJSON.Net/GeoJSONObject.cs
+++ b/src/GeoJSON.Net/GeoJSONObject.cs
@@ -7,6 +7,7 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using GeoJSON.Net.Converters;
 using Newtonsoft.Json.Converters;
 
 namespace GeoJSON.Net
@@ -36,6 +37,7 @@ namespace GeoJSON.Net
         /// The Coordinate Reference System Objects.
         /// </value>
         [JsonProperty(PropertyName = "crs", Required = Required.Default)]
+        [JsonConverter(typeof(CrsConverter))]
         public CoordinateReferenceSystem.ICRSObject CRS { get; set; }
 
         /// <summary>

--- a/src/GeoJSON.Net/Geometry/LineString.cs
+++ b/src/GeoJSON.Net/Geometry/LineString.cs
@@ -7,12 +7,14 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.Linq;
+
 namespace GeoJSON.Net.Geometry
 {
     using System;
     using System.Collections.Generic;
 
-    using GeoJSON.Net.Converters;
+    using Converters;
 
     using Newtonsoft.Json;
 
@@ -26,20 +28,22 @@ namespace GeoJSON.Net.Geometry
         /// Initializes a new instance of the <see cref="LineString"/> class.
         /// </summary>
         /// <param name="coordinates">The coordinates.</param>
-        public LineString(List<IPosition> coordinates)
+        public LineString(IEnumerable<IPosition> coordinates)
         {
             if (coordinates == null)
             {
                 throw new ArgumentNullException("coordinates");
             }
 
-            if (coordinates.Count < 2)
+            var coordsList = coordinates.ToList();
+
+            if (coordsList.Count < 2)
             {
                 throw new ArgumentOutOfRangeException("coordinates", "According to the GeoJSON v1.0 spec a LineString must have at least two or more positions.");
             }
 
-            this.Coordinates = coordinates;
-            this.Type = GeoJSONObjectType.LineString;
+            Coordinates = coordsList;
+            Type = GeoJSONObjectType.LineString;
         }
 
         /// <summary>
@@ -58,7 +62,7 @@ namespace GeoJSON.Net.Geometry
         /// </returns>
         public bool IsLinearRing()
         {
-            return this.Coordinates.Count >= 4 && this.IsClosed();
+            return Coordinates.Count >= 4 && IsClosed();
         }
 
         /// <summary>
@@ -69,17 +73,17 @@ namespace GeoJSON.Net.Geometry
         /// </returns>
         public bool IsClosed()
         {
-            if (this.Coordinates[0] is GeographicPosition) 
+            if (Coordinates[0] is GeographicPosition) 
             {
-                var firstCoordinate = this.Coordinates[0] as GeographicPosition;
-                var lastCoordinate = this.Coordinates[this.Coordinates.Count - 1] as GeographicPosition;
+                var firstCoordinate = Coordinates[0] as GeographicPosition;
+                var lastCoordinate = Coordinates[Coordinates.Count - 1] as GeographicPosition;
 
                 return firstCoordinate.Latitude == lastCoordinate.Latitude
                     && firstCoordinate.Longitude == lastCoordinate.Longitude
                     && firstCoordinate.Altitude == lastCoordinate.Altitude;
             }
             else
-                return this.Coordinates[0].Equals(this.Coordinates[this.Coordinates.Count - 1]);
+                return Coordinates[0].Equals(Coordinates[Coordinates.Count - 1]);
         }
     }
 }


### PR DESCRIPTION
Fixed the merge conflict of @matt-lethargic's pull request, which adds support for deserialization (and serialization) of the `CRS` property. Includes a couple of tests.

This also seems to add support for deserialization of `LineString`s?